### PR TITLE
feature/auth middleware added

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
         "start": "tsc && node bin/www",
         "dev": "nodemon -e js bin/www",
         "jest": "tsc && jest --coverage dist/test/**/*.spec.js",
-        "unit-jest": "tsc && jest --coverage dist/test/entity/*.spec.js dist/test/controller/*.spec.js",
+        "unit-jest": "tsc && jest --coverage dist/test/entity/*.spec.js dist/test/controller/*.spec.js dist/test/middleware/*.spec.js",
         "integration-jest": "tsc && jest --coverage dist/test/integration/*.spec.js",
         "update-views": "(cd ../webapp && npm run build)"
     },

--- a/server/src/controller/oauth2.ts
+++ b/server/src/controller/oauth2.ts
@@ -44,6 +44,7 @@ export default class OAuth2Controller {
         OAuth2Controller.setCookies(ctx, tokens);
         const ticket: LoginTicket = await OAuth2Controller.verifyToken(tokens.id_token);
         const user: User = await OAuth2Controller.getOrCreateUser(ticket.getPayload())
+        if (user === null) ctx.response.status = 500;
         ctx.body = user.name;
     }
 
@@ -69,10 +70,14 @@ export default class OAuth2Controller {
         );
         // create user is doesn't exist
         if (!user) {
-            user = new User();
-            user.email = payload.email;
-            user.name = payload.given_name;
-            user = await userRepository.save(user);
+            try {
+                user = new User();
+                user.email = payload.email;
+                user.name = payload.given_name;
+                user = await userRepository.save(user);
+            } catch {
+                return null;
+            }
         }
         return user;
     }

--- a/server/src/controller/oauth2.ts
+++ b/server/src/controller/oauth2.ts
@@ -2,7 +2,6 @@ import {Context} from "koa";
 import * as googleApis from "googleapis";
 import * as jwt from "jsonwebtoken";
 
-// @ts-ignore // typescript can't find this but it works...
 import * as keys from "../../keys/keys.json";
 import {User} from "../entity/user";
 import {getManager, Repository} from "typeorm";
@@ -19,7 +18,6 @@ const scopes = [
     'https://www.googleapis.com/auth/userinfo.profile'
 ];
 
-//todo: this whole file needs a lot of improvement
 export default class OAuth2Controller {
 
     /**

--- a/server/src/controller/oauth2.ts
+++ b/server/src/controller/oauth2.ts
@@ -1,5 +1,5 @@
-import {BaseContext} from "koa";
-import {google} from 'googleapis';
+import {Context} from "koa";
+import * as googleApis from "googleapis";
 import * as jwt from "jsonwebtoken";
 
 // @ts-ignore // typescript can't find this but it works...
@@ -8,7 +8,7 @@ import {User} from "../entity/user";
 import {getManager, Repository} from "typeorm";
 
 
-const oauth2Client = new google.auth.OAuth2(
+const oauth2Client = new googleApis.google.auth.OAuth2(
     keys.YOUR_CLIENT_ID,
     keys.YOUR_CLIENT_SECRET,
     keys.YOUR_REDIRECT_URL
@@ -26,7 +26,7 @@ export default class OAuth2Controller {
      *
      * Get google cloud endpoint for OAuth2
      */
-    public static async loginUrl(ctx: BaseContext): Promise<void> {
+    public static async loginUrl(ctx: Context): Promise<void> {
         ctx.body = oauth2Client.generateAuthUrl({
             scope: scopes
         });
@@ -39,9 +39,9 @@ export default class OAuth2Controller {
      */
     //todo: jwt verification intermediate step
     //todo: make POST operation
-    public static async tokenExchange(ctx: BaseContext): Promise<void> {
+    public static async tokenExchange(ctx: Context): Promise<void> {
         const oauthCode = ctx.query["code"];
-        const {tokens} = await oauth2Client.getToken(oauthCode)
+        const {tokens} = await oauth2Client.getToken(oauthCode);
         OAuth2Controller.setCookies(ctx, tokens);
         const ticket = await OAuth2Controller.verifyToken(tokens.id_token);
         const user: User = await OAuth2Controller.getOrCreateUser(ticket.payload)

--- a/server/src/controller/oauth2.ts
+++ b/server/src/controller/oauth2.ts
@@ -44,8 +44,11 @@ export default class OAuth2Controller {
         OAuth2Controller.setCookies(ctx, tokens);
         const ticket: LoginTicket = await OAuth2Controller.verifyToken(tokens.id_token);
         const user: User = await OAuth2Controller.getOrCreateUser(ticket.getPayload())
-        if (user === null) ctx.response.status = 500;
-        ctx.body = user.name;
+        if (user === null) {
+            ctx.response.status = 500;
+        } else {
+            ctx.body = user.name;
+        }
     }
 
     public static async verifyToken(idToken: string): Promise<LoginTicket> {
@@ -70,10 +73,10 @@ export default class OAuth2Controller {
         );
         // create user is doesn't exist
         if (!user) {
+            user = new User();
+            user.email = payload.email;
+            user.name = payload.given_name;
             try {
-                user = new User();
-                user.email = payload.email;
-                user.name = payload.given_name;
                 user = await userRepository.save(user);
             } catch {
                 return null;

--- a/server/src/controller/oauth2.ts
+++ b/server/src/controller/oauth2.ts
@@ -4,6 +4,9 @@ import * as jwt from "jsonwebtoken";
 
 // @ts-ignore // typescript can't find this but it works...
 import * as keys from "../../keys/keys.json";
+import {User} from "../entity/user";
+import {getManager, Repository} from "typeorm";
+
 
 const oauth2Client = new google.auth.OAuth2(
     keys.YOUR_CLIENT_ID,
@@ -39,9 +42,40 @@ export default class OAuth2Controller {
     public static async tokenExchange(ctx: BaseContext): Promise<void> {
         const oauthCode = ctx.query["code"];
         const {tokens} = await oauth2Client.getToken(oauthCode)
-        const id_token: any = jwt.decode(tokens.id_token); //todo: make interface
         OAuth2Controller.setCookies(ctx, tokens);
-        ctx.body = id_token.given_name;
+        const ticket = await OAuth2Controller.verifyToken(tokens.id_token);
+        const user: User = await OAuth2Controller.getOrCreateUser(ticket.payload)
+        ctx.body = user.name;
+    }
+
+    public static async verifyToken(idToken: string): Promise<any> {
+        try {
+            return await oauth2Client.verifyIdToken({
+                idToken: idToken,
+                audience: keys.YOUR_CLIENT_ID
+            });
+        } catch {
+            return null;
+        }
+    }
+
+    public static async getOrCreateUser(payload: any): Promise<User> {
+        const userRepository: Repository<User> = getManager().getRepository(User);
+        // get user
+        let user: User = await userRepository.findOne(
+            {
+                where:
+                    {email: payload.email}
+            }
+        );
+        // create user is doesn't exist
+        if (!user) {
+            user = new User();
+            user.email = payload.email;
+            user.name = payload.given_name;
+            user = await userRepository.save(user);
+        }
+        return user;
     }
 
     private static setCookies(ctx, tokens) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 
 import { unprotectedRouter } from "./routes/unprotected";
 import { protectedRouter } from "./routes/protected";
+import {authValidator} from "./middleware/auth-validator";
 
 
 
@@ -27,6 +28,7 @@ export function startApp(): Koa {
     // Enable bodyParser with default options
     app.use(bodyParser());
 
+    app.use(authValidator);
 
     // these routes are NOT protected by the JWT middleware, also include middleware to respond with "Method Not Allowed - 405".
     app.use(unprotectedRouter.routes()).use(unprotectedRouter.allowedMethods());

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,8 +28,6 @@ export function startApp(): Koa {
     // Enable bodyParser with default options
     app.use(bodyParser());
 
-    app.use(authValidator);
-
     // these routes are NOT protected by the JWT middleware, also include middleware to respond with "Method Not Allowed - 405".
     app.use(unprotectedRouter.routes()).use(unprotectedRouter.allowedMethods());
 
@@ -40,6 +38,8 @@ export function startApp(): Koa {
     // something about registering routes here, ie create new routes class
 
     // These routes are protected by the JWT middleware, also include middleware to respond with "Method Not Allowed - 405".
+    app.use(authValidator);
+
     app.use(protectedRouter.routes()).use(protectedRouter.allowedMethods());
 
     //Distribute views if no api routes are matched

--- a/server/src/middleware/auth-validator.ts
+++ b/server/src/middleware/auth-validator.ts
@@ -1,8 +1,9 @@
 import OAuth2Controller from "../controller/oauth2";
 import {User} from "../entity/user";
 import { LoginTicket } from "google-auth-library";
+import {Context} from "koa";
 
-export const authValidator = async (ctx, next) => {
+export const authValidator = async (ctx: Context, next: Function) => {
     const idToken = ctx.cookies.get("ti");
     ctx.state.isAuthenticated = false;
     if (idToken) {
@@ -18,7 +19,7 @@ export const authValidator = async (ctx, next) => {
     await next();
 }
 
-export async function isAuthenticated(ctx, next) {
+export async function isAuthenticated(ctx: Context, next: Function) {
     if (ctx.state.isAuthenticated) {
         await next();
     } else {

--- a/server/src/middleware/auth-validator.ts
+++ b/server/src/middleware/auth-validator.ts
@@ -1,0 +1,23 @@
+import OAuth2Controller from "../controller/oauth2";
+import {User} from "../entity/user";
+
+export const authValidator = async (ctx, next) => {
+    const idToken = ctx.cookies.get("ti");
+    if (!idToken) {
+        ctx.state.isAuthenticated = false;
+    } else {
+        const ticket = await OAuth2Controller.verifyToken(idToken);
+        if (ticket) {
+            const user: User = await OAuth2Controller.getOrCreateUser(ticket.payload);
+            if (user) {
+                ctx.state.user = user;
+                ctx.state.isAuthenticated = true;
+            } else {
+                ctx.isAuthenticated = false;
+            }
+        } else {
+            ctx.state.isAuthenticated = false;
+        }
+    }
+    await next();
+}

--- a/server/src/middleware/auth-validator.ts
+++ b/server/src/middleware/auth-validator.ts
@@ -1,13 +1,14 @@
 import OAuth2Controller from "../controller/oauth2";
 import {User} from "../entity/user";
+import { LoginTicket } from "google-auth-library";
 
 export const authValidator = async (ctx, next) => {
     const idToken = ctx.cookies.get("ti");
     ctx.state.isAuthenticated = false;
     if (idToken) {
-        const ticket = await OAuth2Controller.verifyToken(idToken);
+        const ticket: LoginTicket = await OAuth2Controller.verifyToken(idToken);
         if (ticket) {
-            const user: User = await OAuth2Controller.getOrCreateUser(ticket.payload);
+            const user: User = await OAuth2Controller.getOrCreateUser(ticket.getPayload());
             if (user) {
                 ctx.state.user = user;
                 ctx.state.isAuthenticated = true;

--- a/server/src/middleware/auth-validator.ts
+++ b/server/src/middleware/auth-validator.ts
@@ -17,3 +17,11 @@ export const authValidator = async (ctx, next) => {
     }
     await next();
 }
+
+export async function isAuthenticated(ctx, next) {
+    if (ctx.state.isAuthenticated) {
+        await next();
+    } else {
+        ctx.response.status = 401;
+    }
+}

--- a/server/src/middleware/auth-validator.ts
+++ b/server/src/middleware/auth-validator.ts
@@ -3,20 +3,15 @@ import {User} from "../entity/user";
 
 export const authValidator = async (ctx, next) => {
     const idToken = ctx.cookies.get("ti");
-    if (!idToken) {
-        ctx.state.isAuthenticated = false;
-    } else {
+    ctx.state.isAuthenticated = false;
+    if (idToken) {
         const ticket = await OAuth2Controller.verifyToken(idToken);
         if (ticket) {
             const user: User = await OAuth2Controller.getOrCreateUser(ticket.payload);
             if (user) {
                 ctx.state.user = user;
                 ctx.state.isAuthenticated = true;
-            } else {
-                ctx.state.isAuthenticated = false;
             }
-        } else {
-            ctx.state.isAuthenticated = false;
         }
     }
     await next();

--- a/server/src/middleware/auth-validator.ts
+++ b/server/src/middleware/auth-validator.ts
@@ -13,7 +13,7 @@ export const authValidator = async (ctx, next) => {
                 ctx.state.user = user;
                 ctx.state.isAuthenticated = true;
             } else {
-                ctx.isAuthenticated = false;
+                ctx.state.isAuthenticated = false;
             }
         } else {
             ctx.state.isAuthenticated = false;

--- a/server/src/routes/protected.ts
+++ b/server/src/routes/protected.ts
@@ -1,24 +1,18 @@
 import Router from "koa-router";
 import { UserController } from "../controller/user";
+import {isAuthenticated} from "../middleware/auth-validator";
 
 const protectedRouter: Router = new Router();
 
-async function isAuthenticated(ctx, next) {
-    if (ctx.state.isAuthenticated) {
-        await next();
-    } else {
-        ctx.response.status = 401;
-    }
-}
-
 protectedRouter.prefix("/api")
+protectedRouter.use(isAuthenticated);
 
 // User routes
-protectedRouter.get("/users", isAuthenticated, UserController.getUsers);
-protectedRouter.get("/users/:id", isAuthenticated, UserController.getUser);
-protectedRouter.post("/users", isAuthenticated, UserController.createUser);
-protectedRouter.put("/users/:id", isAuthenticated, UserController.updateUser);
-protectedRouter.delete("/users/:id", isAuthenticated, UserController.deleteUser);
-protectedRouter.delete("/testusers/:id", isAuthenticated, UserController.deleteTestUser);
+protectedRouter.get("/users", UserController.getUsers);
+protectedRouter.get("/users/:id", UserController.getUser);
+protectedRouter.post("/users", UserController.createUser);
+protectedRouter.put("/users/:id", UserController.updateUser);
+protectedRouter.delete("/users/:id", UserController.deleteUser);
+protectedRouter.delete("/testusers/:id", UserController.deleteTestUser);
 
 export { protectedRouter };

--- a/server/src/routes/protected.ts
+++ b/server/src/routes/protected.ts
@@ -3,14 +3,22 @@ import { UserController } from "../controller/user";
 
 const protectedRouter: Router = new Router();
 
+async function isAuthenticated(ctx, next) {
+    if (ctx.state.isAuthenticated) {
+        await next();
+    } else {
+        ctx.response.status = 401;
+    }
+}
+
 protectedRouter.prefix("/api")
 
 // User routes
-protectedRouter.get("/users", UserController.getUsers);
-protectedRouter.get("/users/:id", UserController.getUser);
-protectedRouter.post("/users", UserController.createUser);
-protectedRouter.put("/users/:id", UserController.updateUser);
-protectedRouter.delete("/users/:id", UserController.deleteUser);
-protectedRouter.delete("/testusers/:id", UserController.deleteTestUser);
+protectedRouter.get("/users", isAuthenticated, UserController.getUsers);
+protectedRouter.get("/users/:id", isAuthenticated, UserController.getUser);
+protectedRouter.post("/users", isAuthenticated, UserController.createUser);
+protectedRouter.put("/users/:id", isAuthenticated, UserController.updateUser);
+protectedRouter.delete("/users/:id", isAuthenticated, UserController.deleteUser);
+protectedRouter.delete("/testusers/:id", isAuthenticated, UserController.deleteTestUser);
 
 export { protectedRouter };

--- a/server/test/controller/oauth2.spec.ts
+++ b/server/test/controller/oauth2.spec.ts
@@ -2,6 +2,7 @@ import { createSandbox, SinonSandbox, spy } from 'sinon'
 import {createMockContext, createMockCookies} from '@shopify/jest-koa-mocks';
 import OAuth2Controller from "../../src/controller/oauth2";
 import * as googleApis from "googleapis";
+import { LoginTicket } from "google-auth-library";
 import * as typeorm from "typeorm";
 import {User} from "../../src/entity/user";
 
@@ -26,6 +27,9 @@ describe('Unit test: User endpoint', () => {
     }
 
     const mockTicket = {
+        getPayload(): any | undefined {
+            return this.payload;
+        },
         payload: {
             email: "someEmail@email.com",
             given_name: "firstname",

--- a/server/test/controller/oauth2.spec.ts
+++ b/server/test/controller/oauth2.spec.ts
@@ -27,7 +27,7 @@ describe('Unit test: User endpoint', () => {
     }
 
     const mockTicket = {
-        getPayload(): any | undefined {
+        getPayload(): any {
             return this.payload;
         },
         payload: {

--- a/server/test/controller/oauth2.spec.ts
+++ b/server/test/controller/oauth2.spec.ts
@@ -1,6 +1,9 @@
 import { createSandbox, SinonSandbox, spy } from 'sinon'
-import {createMockContext } from '@shopify/jest-koa-mocks';
+import {createMockContext, createMockCookies} from '@shopify/jest-koa-mocks';
 import OAuth2Controller from "../../src/controller/oauth2";
+import * as googleApis from "googleapis";
+import * as typeorm from "typeorm";
+import {User} from "../../src/entity/user";
 
 describe('Unit test: User endpoint', () => {
     let sandbox: SinonSandbox
@@ -14,6 +17,32 @@ describe('Unit test: User endpoint', () => {
         sandbox.restore()
     })
 
+    function stubGetUserRepository(fakeMethod: any): void {
+        sandbox.stub(typeorm, "getManager").callsFake(() => {
+            return {
+                getRepository: sandbox.stub().withArgs(User).returns(fakeMethod)
+            };
+        });
+    }
+
+    const mockTicket = {
+        payload: {
+            email: "someEmail@email.com",
+            given_name: "firstname",
+            family_name: "lastname"
+        }
+    }
+    const mockUser = {
+        name: 'john',
+        email: 'john@doe.com'
+    }
+    const mockToken = {
+        tokens: {
+            access_token: "accessToken",
+            id_token: "idToken"
+        }
+    }
+
     it('should GET Googleapis loginURL', async () => {
         const ctx = createMockContext();
         await OAuth2Controller.loginUrl(ctx)
@@ -23,7 +52,35 @@ describe('Unit test: User endpoint', () => {
     })
 
     it('should GET jwt tokens and first name', async () => {
-        //todo
+        const ctx = createMockContext();
+        ctx.query["code"] = "abcde";
+
+        sandbox.stub(googleApis.google.auth.OAuth2.prototype, "getToken").returns(Promise.resolve(mockToken));
+        sandbox.stub(googleApis.google.auth.OAuth2.prototype, "verifyIdToken").returns(Promise.resolve(mockTicket));
+        stubGetUserRepository({findOne: () => {return mockUser}})
+        await OAuth2Controller.tokenExchange(ctx);
+
+        expect(ctx.status).toEqual(200);
+        expect(ctx.body).toEqual(mockUser.name);
     })
+
+    it('should FAIL to verify id_token', async () => {
+        sandbox.stub(googleApis.google.auth.OAuth2.prototype, "verifyIdToken").throws(new Error());
+        const response = await OAuth2Controller.verifyToken("");
+
+        expect(response).toEqual(null);
+    })
+
+    // todo: thhis fails because stubbing returns a method, need to figure out multiple stubs later
+
+    // it('should FAIL to get user and make a new one instead', async () => {
+    //     sandbox.stub(googleApis.google.auth.OAuth2.prototype, "verifyIdToken").throws(new Error());
+    //     stubGetUserRepository({findOne: () => {return null}})
+    //     stubGetUserRepository({save: () => {return mockUser}})
+    //
+    //     const response = await OAuth2Controller.getOrCreateUser(mockTicket.payload);
+    //
+    //     expect(response).toEqual(mockUser);
+    // })
 
 })

--- a/server/test/integration/user.spec.ts
+++ b/server/test/integration/user.spec.ts
@@ -6,6 +6,13 @@ import * as appModule from "../../src/index";
 import * as dbModule from "../../src/database/dbclient";
 import { mockUser } from '../interfaces/mockUser';
 
+import * as keys from "../../keys/keys.json";
+const identityToken = keys.YOUR_TEST_IDENTITY_TOKEN;
+
+if (!identityToken) {
+    console.log("MUST INSERT IDENTITY TOKEN FOR INTEGRATION TESTING");
+}
+
 describe('Integration: Users endpoint', () => {
     let app: Koa
     let db: Connection
@@ -33,13 +40,18 @@ describe('Integration: Users endpoint', () => {
     });
     
     it('should send back array of users', async () => {
-        const response: request.Response = await request(app.callback()).get('/api/users')
+        const response: request.Response = await request(app.callback())
+            .get('/api/users')
+            .set("Cookie", "ti="+identityToken);
 
         expect(response.status).toBe(200);
         expect(response.body.length).toBeGreaterThanOrEqual(0)
     });
     it('should be able to create new user', async () => {
-        const response: request.Response = await request(app.callback()).post('/api/users').send(newUser)
+        const response: request.Response = await request(app.callback())
+            .post('/api/users')
+            .send(newUser)
+            .set("Cookie", "ti="+identityToken);
 
         expect(response.status).toBe(201);
         expect(response.body.name).toEqual(newUser.name)
@@ -49,7 +61,9 @@ describe('Integration: Users endpoint', () => {
         console.log("from create: " + id)
     });
     it('should be able to get existing user by id', async () => {
-        const response: request.Response = await request(app.callback()).get('/api/users/' + id)
+        const response: request.Response = await request(app.callback())
+            .get('/api/users/' + id)
+            .set("Cookie", "ti="+identityToken);
         
         expect(response.status).toBe(200);
         expect(response.body.name).toEqual(newUser.name)
@@ -58,12 +72,16 @@ describe('Integration: Users endpoint', () => {
         console.log("from get: " + response.body.id)
     });
     it('should be able to delete the newly created user', async () => {
-        const response: request.Response = await request(app.callback()).delete('/api/testusers/' + id)
+        const response: request.Response = await request(app.callback())
+            .delete('/api/testusers/' + id)
+            .set("Cookie", "ti="+identityToken);
         
         expect(response.status).toBe(204);
     });
     it('should not be able to get delete a user which doesnt exist', async () => {
-        const response: request.Response = await request(app.callback()).delete('/api/users/' + 0)
+        const response: request.Response = await request(app.callback())
+            .delete('/api/users/' + 0)
+            .set("Cookie", "ti="+identityToken);
         
         expect(response.status).toBe(400);
     });

--- a/server/test/middleware/auth-validator.spec.ts
+++ b/server/test/middleware/auth-validator.spec.ts
@@ -18,6 +18,9 @@ describe('Unit test: User endpoint', () => {
 
     const next = function(){return;};
     const mockTicket = {
+        getPayload(): any | undefined {
+            return this.payload;
+        },
         payload: {
             email: "someEmail@email.com",
             given_name: "firstname",

--- a/server/test/middleware/auth-validator.spec.ts
+++ b/server/test/middleware/auth-validator.spec.ts
@@ -1,6 +1,6 @@
 import {createMockContext, createMockCookies} from "@shopify/jest-koa-mocks";
 import { createSandbox, SinonSandbox, spy } from 'sinon'
-import {authValidator} from "../../src/middleware/auth-validator";
+import {authValidator, isAuthenticated} from "../../src/middleware/auth-validator";
 import OAuth2Controller from "../../src/controller/oauth2";
 
 
@@ -16,7 +16,7 @@ describe('Unit test: User endpoint', () => {
         sandbox.restore()
     })
 
-    const next = function(){return;};
+    const next = function(){};
     const mockTicket = {
         getPayload(): any | undefined {
             return this.payload;
@@ -82,5 +82,22 @@ describe('Unit test: User endpoint', () => {
         expect(ctx.state.isAuthenticated).toBe(false);
     })
 
+    it('should SET response status = 401', async () => {
+        const ctx = createMockContext();
+        ctx.state.isAuthenticated = false;
+
+        await isAuthenticated(ctx, next);
+        expect(ctx.response.status).toBe(401);
+    })
+
+    // todo: this test needs to be improved to spy next() to see if called
+    it('should CALL the next function', async () => {
+        const ctx = createMockContext();
+        ctx.state.isAuthenticated = true;
+
+        await isAuthenticated(ctx, next);
+
+        expect(ctx.response.status).toEqual(404);
+    })
 
 })

--- a/server/test/middleware/auth-validator.spec.ts
+++ b/server/test/middleware/auth-validator.spec.ts
@@ -1,0 +1,83 @@
+import {createMockContext, createMockCookies} from "@shopify/jest-koa-mocks";
+import { createSandbox, SinonSandbox, spy } from 'sinon'
+import {authValidator} from "../../src/middleware/auth-validator";
+import OAuth2Controller from "../../src/controller/oauth2";
+
+
+
+describe('Unit test: User endpoint', () => {
+    let sandbox: SinonSandbox = createSandbox();
+
+    beforeEach(() => {
+        sandbox = createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    const next = function(){return;};
+    const mockTicket = {
+        payload: {
+            email: "someEmail@email.com",
+            given_name: "firstname",
+            family_name: "lastname"
+        }
+    }
+    const mockUser = {
+        name: 'john',
+        email: 'john@doe.com'
+    }
+
+    it('should SET isAuthenticated=true and user objects', async () => {
+        const ctx = createMockContext();
+        ctx.cookies = createMockCookies({
+            ti: "someJwtToken"
+        });
+
+        sandbox.stub(OAuth2Controller, "verifyToken").returns(mockTicket);
+        sandbox.stub(OAuth2Controller, "getOrCreateUser").returns(mockUser);
+        await authValidator(ctx, next);
+
+        expect(ctx.state.isAuthenticated).toBe(true);
+        expect(ctx.state.user).toBe(mockUser);
+    })
+
+    it('should SET isAuthenticated=false (no jwt)', async () => {
+        const ctx = createMockContext();
+
+        sandbox.stub(OAuth2Controller, "verifyToken").returns(mockTicket);
+        sandbox.stub(OAuth2Controller, "getOrCreateUser").returns(mockUser);
+        await authValidator(ctx, next);
+
+        expect(ctx.state.isAuthenticated).toBe(false);
+    })
+
+    it('should SET isAuthenticated=false (invalid jwt)', async () => {
+        const ctx = createMockContext();
+        ctx.cookies = createMockCookies({
+            ti: "someJwtToken"
+        });
+
+        sandbox.stub(OAuth2Controller, "verifyToken").returns(undefined);
+        sandbox.stub(OAuth2Controller, "getOrCreateUser").returns(mockUser);
+        await authValidator(ctx, next);
+
+        expect(ctx.state.isAuthenticated).toBe(false);
+    })
+
+    it('should SET isAuthenticated=false (failed to create user)', async () => {
+        const ctx = createMockContext();
+        ctx.cookies = createMockCookies({
+            ti: "someJwtToken"
+        });
+
+        sandbox.stub(OAuth2Controller, "verifyToken").returns(mockTicket);
+        sandbox.stub(OAuth2Controller, "getOrCreateUser").returns(undefined);
+        await authValidator(ctx, next);
+
+        expect(ctx.state.isAuthenticated).toBe(false);
+    })
+
+
+})


### PR DESCRIPTION
i put the getOrCreate inside the oauth controller because its being used by 2 methods (kind of unnecessarily, but i have a reason which i can go over later).

Right now since email isn't a primary key typeorm will do a sequential search on users to get the correct one. I'll push it as a branch for you guys to look at and i'll write the unit tests later tonight.

One more note, since this user interaction is inside oauth2, any changes to the user schema will need to be changed here too.